### PR TITLE
Bugfix: MBLL remove the scaling factor of 0.434 (1/ln(10)) introduced…

### DIFF
--- a/bst_plugin/mbll/process_nst_mbll.m
+++ b/bst_plugin/mbll/process_nst_mbll.m
@@ -885,9 +885,6 @@ extinction_hbo_hbr_ref = [
 1000	1024	206.784;
 ];
 
-extinction_hbo_hbr_ref(:,2) = extinction_hbo_hbr_ref(:,2) * 2.303;
-extinction_hbo_hbr_ref(:,3) = extinction_hbo_hbr_ref(:,3) * 2.303;
-
 if any(wavelengths > extinction_hbo_hbr_ref(end,1)) || ...
     any(wavelengths < extinction_hbo_hbr_ref(1,1))
     raise(MException('NSTValueError', ['Hb exctinction not available for '...


### PR DESCRIPTION
… by #56

Remove the correction that was used when we were using ln instead of log10 in the dOD calculation.